### PR TITLE
Tank Type Change

### DIFF
--- a/GameData/HGA/Proton/mm_config/realism_overhaul/ro_breeze_engines.cfg
+++ b/GameData/HGA/Proton/mm_config/realism_overhaul/ro_breeze_engines.cfg
@@ -104,11 +104,16 @@
 	@breakingForce = 250
 	@breakingTorque = 250
 	@maxTemp = 1973.15
-	@MODULE[ModuleRCS]
+	
+	!MODULE[ModuleRCS]
 	{
-		@name = ModuleRCSFX
-		@thrusterPower = 0.013
-		!resourceName = DELETE
+	}
+	
+	MODULE
+	{
+	Name = ModuleRCS
+	thrusterPower = 0.013
+		
 		PROPELLANT
 		{
 			name = UDMH
@@ -120,10 +125,10 @@
 			name = NTO
 			ratio = 0.587
 		}
-		@atmosphereCurve
+		atmosphereCurve
 		{
-			@key,0 = 0 247
-			@key,1 = 1 82.08
+			key,0 = 0 247
+			key,1 = 1 82.08
 		}
 	}
 	@MODULE[ModuleEngines*]

--- a/GameData/HGA/Proton/mm_config/realism_overhaul/ro_breeze_tanks.cfg
+++ b/GameData/HGA/Proton/mm_config/realism_overhaul/ro_breeze_tanks.cfg
@@ -23,7 +23,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 4594.62
-		type = Default
+		type = ServiceModule
 		basemass = -1
 		TANK
 		{
@@ -64,7 +64,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 12900.28
-		type = Default
+		type = ServiceModule
 		basemass = -1
 		TANK
 		{
@@ -101,7 +101,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 39
-		type = Default
+		type = ServiceModule
 		basemass = -1
 	}
 }


### PR DESCRIPTION
Changed fuel tank types on Briz Tanks. (Mainly important for the small spherical tank, according to the proton manual the tanks ARE pressurized.)
