### PR TITLE
Add epoch bump to .netkan

### DIFF
--- a/ProtonMBreezeM.netkan
+++ b/ProtonMBreezeM.netkan
@@ -12,6 +12,7 @@
 	},
 	//"$kref": "#/ckan/github/InsaneDruid/Proton-M",
 	"$kref": "#/ckan/spacedock/177",
+	"x_netkan_epoch": 1,
 	"depends": [
 		{ "name": "ModuleManager" }
 	],


### PR DESCRIPTION
Because your version numbers have gone backwards, CKAN is reporting the wrong Max KSP" version in the client. This change puts you into a new numbering order.