### PR TITLE
Fix ProtonMBreezeM.netkan to valid json

### DIFF
--- a/ProtonMBreezeM.netkan
+++ b/ProtonMBreezeM.netkan
@@ -10,7 +10,6 @@
 		"homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/120548-105-proton-m-breeze-m/",
 		"repository": "https://github.com/InsaneDruid/Proton-M"
 	},
-	//"$kref": "#/ckan/github/InsaneDruid/Proton-M",
 	"$kref": "#/ckan/spacedock/177",
 	"x_netkan_epoch": 1,
 	"depends": [


### PR DESCRIPTION
## Motivation
`//` comments are not valid JSON (at least as per RFC 8259), and are preventing CKAN's download count gathering bot from catching this mod's download counts:
`Failed decoding count for ProtonMBreezeM: Expecting property name enclosed in double quotes: line 13 column 2 (char 452)`

## Changes
Remove the commented-out kref line. If you ever want to revert back to GitHub as  download source, it should be quite easy to achieve even without that comment (and we can help you anytime).